### PR TITLE
Configure symbols map size via CLI argument

### DIFF
--- a/examples/cpp/pyperf/PyPerf.cc
+++ b/examples/cpp/pyperf/PyPerf.cc
@@ -90,6 +90,7 @@ int main(int argc, char** argv) {
   // Default argument values
   std::vector<uint64_t> pids;
   uint64_t updateIntervalSecs = 10;
+  uint64_t symbolsMapSize = 16384;
   uint64_t sampleRate = 0;
   uint64_t sampleFreq = 0;
   uint64_t duration = 0;
@@ -106,6 +107,7 @@ int main(int argc, char** argv) {
     found = found || parseIntArg({"-F", "--frequency"}, sampleFreq);
     found = found || parseIntArg({"-d", "--duration"}, duration);
     found = found || parseIntArg({"--update-interval"}, updateIntervalSecs);
+    found = found || parseIntArg({"--symbols-map-size"}, symbolsMapSize);
     found = found || parseIntArg({"-v", "--verbose"}, verbosityLevel);
     found = found || parseStrArg({"-o", "--output"}, output);
     if (!found) {
@@ -141,7 +143,7 @@ int main(int argc, char** argv) {
     ebpf::pyperf::PyPerfProfiler profiler;
     profiler.update_interval = std::chrono::seconds{updateIntervalSecs};
 
-    auto res = profiler.init();
+    auto res = profiler.init(symbolsMapSize);
     if (res != ebpf::pyperf::PyPerfProfiler::PyPerfResult::SUCCESS) {
       std::exit((int)res);
     }

--- a/examples/cpp/pyperf/PyPerfProfiler.cc
+++ b/examples/cpp/pyperf/PyPerfProfiler.cc
@@ -57,7 +57,6 @@ const static int kGetThreadStateProgIdx = 1;
 
 const static std::string kNumCpusFlag("-DNUM_CPUS=");
 const static std::string kSymbolsHashSizeFlag("-D__SYMBOLS_SIZE__=");
-const static int kSymbolsHashSize = 16384;
 
 namespace {
 
@@ -163,10 +162,10 @@ void handleLostSamplesCallback(void* cb_cookie, uint64_t lost_cnt) {
   profiler->handleLostSamples(lost_cnt);
 }
 
-PyPerfProfiler::PyPerfResult PyPerfProfiler::init() {
+PyPerfProfiler::PyPerfResult PyPerfProfiler::init(int symbolsMapSize) {
   std::vector<std::string> cflags;
   cflags.emplace_back(kNumCpusFlag + std::to_string(::sysconf(_SC_NPROCESSORS_ONLN)));
-  cflags.emplace_back(kSymbolsHashSizeFlag + std::to_string(kSymbolsHashSize));
+  cflags.emplace_back(kSymbolsHashSizeFlag + std::to_string(symbolsMapSize));
   cflags.emplace_back(kPythonStackProgIdxFlag + std::to_string(kPythonStackProgIdx));
   cflags.emplace_back(kGetThreadStateProgIdxFlag + std::to_string(kGetThreadStateProgIdx));
 

--- a/examples/cpp/pyperf/PyPerfProfiler.h
+++ b/examples/cpp/pyperf/PyPerfProfiler.h
@@ -65,7 +65,7 @@ class PyPerfProfiler {
   };
 
   // init must be invoked exactly once before invoking profile
-  PyPerfResult init();
+  PyPerfResult init(int symbolsMapSize = 16384);
 
   PyPerfResult profile(int64_t sampleRate, int64_t sampleFreq, int64_t duration,
                        PyPerfSampleProcessor* processor);


### PR DESCRIPTION
Tested using:
```bash
./PyPerf --symbols-map-size $((1024 * 512)) &
bpftool map show
```
```
...
67: hash  name symbols  flags 0x0
	key 224B  value 4B  max_entries 524288  memlock 155193344B
...
```