### PR TITLE
Ensure len(co_varnames) > 0 before reading first var name

### DIFF
--- a/examples/cpp/pyperf/PyPerfBPFProgram.cc
+++ b/examples/cpp/pyperf/PyPerfBPFProgram.cc
@@ -17,6 +17,8 @@ extern const std::string PYPERF_BPF_PROGRAM = R"(
 #include <linux/sched.h>
 #include <uapi/linux/ptrace.h>
 
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+
 #define BAD_THREAD_ID (~0)
 
 // Maximum threads: 32x8 = 256
@@ -509,7 +511,7 @@ get_classname(
   // the first argument. If it's 'self', we get the type and it's name, if it's
   // 'cls', we just get the name. This is not perfect but there is no better way
   // to figure this out from the code object.
-  char argname[max_t(size_t, sizeof("self"), sizeof("cls"))];
+  char argname[MAX(sizeof("self"), sizeof("cls"))];
   result |= get_first_arg_name(code_ptr, offsets, argname, sizeof(argname));
 
   // compare strings as ints to save instructions

--- a/examples/cpp/pyperf/PyPerfBPFProgram.cc
+++ b/examples/cpp/pyperf/PyPerfBPFProgram.cc
@@ -509,7 +509,7 @@ get_classname(
   // the first argument. If it's 'self', we get the type and it's name, if it's
   // 'cls', we just get the name. This is not perfect but there is no better way
   // to figure this out from the code object.
-  char argname[max_t(size_t, sizeof("self"), sizeof("cls"))] = {};
+  char argname[max_t(size_t, sizeof("self"), sizeof("cls"))];
   result |= get_first_arg_name(code_ptr, offsets, argname, sizeof(argname));
 
   // compare strings as ints to save instructions

--- a/examples/cpp/pyperf/PyPerfBPFProgram.cc
+++ b/examples/cpp/pyperf/PyPerfBPFProgram.cc
@@ -25,9 +25,9 @@ extern const std::string PYPERF_BPF_PROGRAM = R"(
 #define THREAD_STATES_PER_PROG 32
 #define THREAD_STATES_PROG_CNT 8
 
-// Maximum Python stack frames: 20x4 = 80
-#define PYTHON_STACK_FRAMES_PER_PROG 20
-#define PYTHON_STACK_PROG_CNT 4
+// Maximum Python stack frames: 16x5 = 80
+#define PYTHON_STACK_FRAMES_PER_PROG 16
+#define PYTHON_STACK_PROG_CNT 5
 #define STACK_MAX_LEN (PYTHON_STACK_FRAMES_PER_PROG * PYTHON_STACK_PROG_CNT)
 
 #define CLASS_NAME_LEN 32

--- a/examples/cpp/pyperf/PyPerfBPFProgram.cc
+++ b/examples/cpp/pyperf/PyPerfBPFProgram.cc
@@ -483,7 +483,7 @@ get_first_arg_name(
   void* args_ptr;
   result |= bpf_probe_read_user(&args_ptr, sizeof(void*), code_ptr + offsets->PyCodeObject.co_varnames);
   result |= bpf_probe_read_user(&ob_size, sizeof(ob_size), args_ptr + offsets->String.size); // String.size is PyVarObject.ob_size
-  if (ob_size > 0) {
+  if (result == 0 && ob_size > 0) {
     result |= bpf_probe_read_user(&args_ptr, sizeof(void*), args_ptr + offsets->PyTupleObject.ob_item);
     result |= bpf_probe_read_user_str(argname, maxlen, args_ptr + offsets->String.data);
   } else {

--- a/examples/cpp/pyperf/PyPerfBPFProgram.cc
+++ b/examples/cpp/pyperf/PyPerfBPFProgram.cc
@@ -509,7 +509,7 @@ get_classname(
   // the first argument. If it's 'self', we get the type and it's name, if it's
   // 'cls', we just get the name. This is not perfect but there is no better way
   // to figure this out from the code object.
-  char argname[5]; // sizeof('self') + 1
+  char argname[max_t(size_t, sizeof("self"), sizeof("cls"))] = {};
   result |= get_first_arg_name(code_ptr, offsets, argname, sizeof(argname));
 
   // compare strings as ints to save instructions


### PR DESCRIPTION
Before this fix - a function like
```
def f():
   while 1:
       pass
```

would show as `[Error 1]`. Now it's not.

I still get
```
Ready to profile
1001 samples collected
0 samples lost
0 samples with truncated stack
1001 Python symbol errors
0 times Python symbol lost
0 kernel stack errors
0 errors
```

when running. Will look into what are those other errors...