### PR TITLE
Change null f_code case into per-frame error

### DIFF
--- a/examples/cpp/pyperf/PyPerfCollapsedPrinter.cc
+++ b/examples/cpp/pyperf/PyPerfCollapsedPrinter.cc
@@ -93,8 +93,13 @@ void PyPerfCollapsedPrinter::processSamples(
     for (auto it = sample.pyStackIds.crbegin(); it != sample.pyStackIds.crend(); ++it) {
       const auto stackId = *it;
       if (stackId < 0) {
-        std::fprintf(output_file, ";[Error %d]_[pe]", -stackId);
-        symbolErrors++;
+        if (stackId == FRAME_CODE_IS_NULL) {
+          std::fprintf(output_file, ";(missing)_[pe]");
+        }
+        else {
+          std::fprintf(output_file, ";[Error %d]_[pe]", -stackId);
+          symbolErrors++;
+        }
       }
       else {
         auto symbIt = symbols.find(stackId);

--- a/examples/cpp/pyperf/PyPerfType.h
+++ b/examples/cpp/pyperf/PyPerfType.h
@@ -58,9 +58,6 @@ ERROR_EMPTY_STACK:
   The frame pointer in the current PyThreadState is NULL, meaning the Python stack for this Python
   thread is empty.
 
-ERROR_FRAME_CODE_IS_NULL:
-  The f_code field of a stack frame points to NULL.
-
 ERROR_BAD_FSBASE:
   Reading data from the thread descriptor (at %fs) faulted. This can happen when a new thread is created but pthreads
   has not initialized in that thread yet.
@@ -82,11 +79,12 @@ enum error_code {
   ERROR_TOO_MANY_THREADS = 4,
   ERROR_THREAD_STATE_NOT_FOUND = 5,
   ERROR_EMPTY_STACK = 6,
-  ERROR_FRAME_CODE_IS_NULL = 7,
+  // ERROR_FRAME_CODE_IS_NULL = 7,
   ERROR_BAD_FSBASE = 8,
   ERROR_INVALID_PTHREADS_IMPL = 9,
   ERROR_THREAD_STATE_HEAD_NULL = 10,
   ERROR_BAD_THREAD_STATE = 11,
+  ERROR_CALL_FAILED = 12,
 };
 
 /**
@@ -210,6 +208,7 @@ typedef struct event {
   // hashmap with Symbols and only store the ids here
   int32_t stack_len;
   int32_t stack[STACK_MAX_LEN];
+#define FRAME_CODE_IS_NULL 0x80000001
 } Event;
 
 struct PyPerfSample {

--- a/examples/cpp/pyperf/PyPerfType.h
+++ b/examples/cpp/pyperf/PyPerfType.h
@@ -70,6 +70,9 @@ ERROR_THREAD_STATE_HEAD_NULL:
 
 ERROR_BAD_THREAD_STATE:
   Reading a field from a thread state in the thread states list failed.
+
+ERROR_CALL_FAILED:
+  A tail call to a BPF program failed.
 */
 enum error_code {
   ERROR_NONE = 0,


### PR DESCRIPTION
Previously it was unclear what the resulting stack looked like when we got `ERROR_FRAME_CODE_IS_NULL` because that error was emitted on a whole-stack basis. Now the error is emitted per each frame whose `f_code` field is null. In such a case the string `(missing)` will be emitted.