### PR TITLE
Write output filename to stderr after dump stats

### DIFF
--- a/examples/cpp/pyperf/PyPerfCollapsedPrinter.cc
+++ b/examples/cpp/pyperf/PyPerfCollapsedPrinter.cc
@@ -141,6 +141,9 @@ void PyPerfCollapsedPrinter::processSamples(
     if (rename(output_.c_str(), final_path) == -1) {
       std::fprintf(stderr, "rename(\"%s\", \"%s\"): %s\n", output_.c_str(), final_path, strerror(errno));
     }
+    else {
+      std::fprintf(stderr, "Wrote %s\n", final_path);
+    }
   }
 }
 


### PR DESCRIPTION
Example:
```
...
0 kernel stack errors
0 errors
Wrote /tmp/out.txt.2021060317091469
```