### PR TITLE
Fix error when attempting to read class name from cellvar cls/self

### DIFF
--- a/examples/cpp/pyperf/PyPerfBPFProgram.cc
+++ b/examples/cpp/pyperf/PyPerfBPFProgram.cc
@@ -538,7 +538,7 @@ get_classname(
   // read f_localsplus[0]:
   result |= bpf_probe_read_user(&tmp, sizeof(void*), cur_frame + offsets->PyFrameObject.f_localsplus);
   if (tmp == NULL) {
-    // self/cls is a cellvar. tough luck :/
+    // self/cls is a cellvar, deleted, or not an argument. tough luck :/
     return result;
   }
 

--- a/examples/cpp/pyperf/PyPerfBPFProgram.cc
+++ b/examples/cpp/pyperf/PyPerfBPFProgram.cc
@@ -548,7 +548,7 @@ get_classname(
   }
   result |= bpf_probe_read_user(&tmp, sizeof(void*), tmp + offsets->PyTypeObject.tp_name);
   result |= bpf_probe_read_user_str(&symbol->classname, sizeof(symbol->classname), tmp);
-  return result;
+  return (result < 0) ? result : 0;
 }
 
 static __always_inline int
@@ -566,10 +566,14 @@ read_symbol_names(
   // read PyCodeObject's filename into symbol
   result |= bpf_probe_read_user(&pystr_ptr, sizeof(void*), code_ptr + offsets->PyCodeObject.co_filename);
   result |= bpf_probe_read_user_str(&symbol->file, sizeof(symbol->file), pystr_ptr + offsets->String.data);
+  if (result < 0) {
+    return result;
+  }
+  result = 0;
   // read PyCodeObject's name into symbol
   result |= bpf_probe_read_user(&pystr_ptr, sizeof(void*), code_ptr + offsets->PyCodeObject.co_name);
   result |= bpf_probe_read_user_str(&symbol->name, sizeof(symbol->name), pystr_ptr + offsets->String.data);
-  return result;
+  return (result < 0) ? result : 0;
 }
 
 /**

--- a/examples/cpp/pyperf/PyPerfBPFProgram.cc
+++ b/examples/cpp/pyperf/PyPerfBPFProgram.cc
@@ -492,6 +492,10 @@ get_first_arg_name(
   if (result == 0 && ob_size > 0) {
     result |= bpf_probe_read_user(&args_ptr, sizeof(void*), args_ptr + offsets->PyTupleObject.ob_item);
     result |= bpf_probe_read_user_str(argname, maxlen, args_ptr + offsets->String.data);
+    if (result < 0) {
+      return result;
+    }
+    result = 0;
   } else {
     // if we're not reading into it - clean it up to please the verifier.
     #pragma unroll


### PR DESCRIPTION
`cls`/`self` may be a cellvar, in which case it's (obviously) not stored in fast locals (`localsplus`). Affected methods use `LOAD_DEREF <n>` instead of `LOAD_FAST 0` for `self`/`cls`. In such a case we would have to find the index of the cell via `co_cellvars` to get the class name. Seems like too much hassle atm. This fixes the bug in the meanwhile.