### PR TITLE
Translate numeric code to error string (to use in frames)

### DIFF
--- a/examples/cpp/pyperf/PyPerfCollapsedPrinter.cc
+++ b/examples/cpp/pyperf/PyPerfCollapsedPrinter.cc
@@ -65,6 +65,24 @@ void PyPerfCollapsedPrinter::prepare() {
   }
 }
 
+const char *PyPerfCollapsedPrinter::sample_strerror(enum error_code error) {
+  switch (error) {
+    case ERROR_NONE: return "ERROR_NONE";
+    case ERROR_MISSING_PYSTATE: return "ERROR_MISSING_PYSTATE";
+    case ERROR_THREAD_STATE_NULL: return "ERROR_THREAD_STATE_NULL";
+    case ERROR_INTERPRETER_NULL: return "ERROR_INTERPRETER_NULL";
+    case ERROR_TOO_MANY_THREADS: return "ERROR_TOO_MANY_THREADS";
+    case ERROR_THREAD_STATE_NOT_FOUND: return "ERROR_THREAD_STATE_NOT_FOUND";
+    case ERROR_EMPTY_STACK: return "ERROR_EMPTY_STACK";
+    case ERROR_BAD_FSBASE: return "ERROR_BAD_FSBASE";
+    case ERROR_INVALID_PTHREADS_IMPL: return "ERROR_INVALID_PTHREADS_IMPL";
+    case ERROR_THREAD_STATE_HEAD_NULL: return "ERROR_THREAD_STATE_HEAD_NULL";
+    case ERROR_BAD_THREAD_STATE: return "ERROR_BAD_THREAD_STATE";
+    case ERROR_CALL_FAILED: return "ERROR_CALL_FAILED";
+    default: return "ERROR_UNKNOWN_CODE";
+  }
+}
+
 void PyPerfCollapsedPrinter::processSamples(
     const std::vector<PyPerfSample>& samples, PyPerfProfiler* util) {
   unsigned int errors = 0;
@@ -85,7 +103,7 @@ void PyPerfCollapsedPrinter::processSamples(
       truncatedStack++;
       break;
     case STACK_STATUS_ERROR:
-      std::fprintf(output_file, ";[Sample Error %d]_[pe]", sample.errorCode);
+      std::fprintf(output_file, ";[Sample Error %s]_[pe]", sample_strerror((enum error_code)sample.errorCode));
       errors++;
       break;
     }

--- a/examples/cpp/pyperf/PyPerfCollapsedPrinter.h
+++ b/examples/cpp/pyperf/PyPerfCollapsedPrinter.h
@@ -25,6 +25,7 @@ class PyPerfCollapsedPrinter : public PyPerfSampleProcessor {
   std::FILE *output_file;
 
   void open_new();
+  const char *sample_strerror(enum error_code error);
 };
 
 }  // namespace pyperf


### PR DESCRIPTION
Example:
```
ipython3-620124/620447;[Sample Error ERROR_THREAD_STATE_NOT_FOUND]_[pe];entry_SYSCALL_64_after_hwframe_[k];do_syscall_64_[k];__x64_sys_futex_[k];do_futex_[k];_raw_spin_lock_[k] 1
ipython3-620124/620124;[Sample Error ERROR_EMPTY_STACK]_[pe];entry_SYSCALL_64_after_hwframe_[k];do_syscall_64_[k];__x64_sys_clone_[k];_do_fork_[k];copy_process_[k];__memcg_kmem_charge_[k];__memcg_kmem_charge_memcg_[k];page_counter_try_charge_[k];apic_timer_interrupt_[k];smp_apic_timer_interrupt_[k];irq_exit_[k];__softirqentry_text_start_[k];run_rebalance_domains_[k];update_blocked_averages_[k];_raw_spin_unlock_irqrestore_[k] 1
ipython3-620124/620472;[Sample Error ERROR_THREAD_STATE_NOT_FOUND]_[pe] 1
ipython3-620124/620470;[Sample Error ERROR_THREAD_STATE_NOT_FOUND]_[pe];entry_SYSCALL_64_after_hwframe_[k];do_syscall_64_[k];__x64_sys_exit_[k];do_exit_[k];taskstats_exit_[k];netlink_unicast_[k];netlink_trim_[k];pskb_expand_head_[k];ksize_[k];__ksize_[k] 1
ipython3-620124/620456;[Sample Error ERROR_EMPTY_STACK]_[pe];page_fault_[k];do_page_fault_[k];__do_page_fault_[k];do_user_addr_fault_[k];handle_mm_fault_[k];__handle_mm_fault_[k];do_wp_page_[k];copy_page_[k] 1
ipython3-620124/620464;[Sample Error ERROR_THREAD_STATE_NOT_FOUND]_[pe];entry_SYSCALL_64_after_hwframe_[k];do_syscall_64_[k];__x64_sys_exit_[k];do_exit_[k];exit_mm_release_[k];mm_release_[k];do_futex_[k];futex_wake_[k];get_futex_key_[k];get_user_pages_fast_[k] 1
ipython3-620124/620480;[Sample Error ERROR_EMPTY_STACK]_[pe];page_fault_[k];do_page_fault_[k];__do_page_fault_[k];do_user_addr_fault_[k];handle_mm_fault_[k];__handle_mm_fault_[k];do_wp_page_[k];wp_page_copy_[k];alloc_pages_vma_[k];__alloc_pages_nodemask_[k];get_page_from_freelist_[k];clear_page_erms_[k] 1
ipython3-620124/620124;[Sample Error ERROR_BAD_FSBASE]_[pe];page_fault_[k];do_page_fault_[k];__do_page_fault_[k];do_user_addr_fault_[k];handle_mm_fault_[k];__handle_mm_fault_[k];do_wp_page_[k];wp_page_copy_[k];mem_cgroup_commit_charge_[k] 1

```