### PR TITLE
Ensure --fs-offset, --stack-offset are given

### DIFF
--- a/examples/cpp/pyperf/PyPerf.cc
+++ b/examples/cpp/pyperf/PyPerf.cc
@@ -143,6 +143,16 @@ int main(int argc, char** argv) {
     return 1;
   }
 
+  // checking against 0 which technically is a legit offset, but it won't ever happen
+  // for these fields, so it's okay as a sentinel.
+  if (fsOffset == 0) {
+    std::fprintf(stderr, "--fs-offset must be given!\n");
+    return 1;
+  } else if (stackOffset == 0) {
+    std::fprintf(stderr, "--stack-offset must be given!\n");
+    return 1;
+  }
+
   if (sampleRate != 0) {
     ebpf::pyperf::logInfo(1, "Profiling Sample Rate: %" PRIu64 "\n",
                           sampleRate);

--- a/examples/cpp/pyperf/PyPerf.cc
+++ b/examples/cpp/pyperf/PyPerf.cc
@@ -146,10 +146,10 @@ int main(int argc, char** argv) {
   // checking against 0 which technically is a legit offset, but it won't ever happen
   // for these fields, so it's okay as a sentinel.
   if (fsOffset == 0) {
-    std::fprintf(stderr, "--fs-offset must be given!\n");
+    std::fprintf(stderr, "--fs-offset must be given (see https://github.com/Jongy/bpf_get_fs_offset for an eBPF program that calculates it)\n");
     return 1;
   } else if (stackOffset == 0) {
-    std::fprintf(stderr, "--stack-offset must be given!\n");
+    std::fprintf(stderr, "--stack-offset must be given (see https://github.com/Jongy/bpf_get_stack_offset for an eBPF program that calculates it)\n");
     return 1;
   }
 


### PR DESCRIPTION
PyPerf won't operate correctly without them; they have no default value.