### PR TITLE
Fix native stacks

### DIFF
--- a/examples/cpp/pyperf/PyPerfBPFProgram.cc
+++ b/examples/cpp/pyperf/PyPerfBPFProgram.cc
@@ -327,8 +327,8 @@ on_event(struct pt_regs* ctx) {
           &user_regs, sizeof(user_regs),
           // Note - BCC emits an implicit bpf_probe_read_kernel() here (for the deref of 'task').
           // I don't like the implicitness (and it will be something we'll need to fix if we're ever
-          // to move from BCC). But meanwhile, I tried to change it to explicit and the BPF assembly
-          // varies to much as I prefer to avoid this change now ;(
+          // to move from BCC). Meanwhile, I tried to change it to be explicit but the BPF assembly
+          // varies too much so I prefer to avoid this change now ;(
           (struct pt_regs *)(*(unsigned long*)((unsigned long)task + STACK_OFS) + THREAD_SIZE -
                             TOP_OF_KERNEL_STACK_PADDING) - 1);
     }

--- a/examples/cpp/pyperf/PyPerfBPFProgram.cc
+++ b/examples/cpp/pyperf/PyPerfBPFProgram.cc
@@ -315,13 +315,20 @@ on_event(struct pt_regs* ctx) {
 
     // Are we in user mode?
     if (cs & 3) {
+      // Yes - use the registers context given to the BPF program
       user_regs = *ctx;
     }
     else {
+      // No - use the registers context of usermode, that is stored on the stack.
+
       // The third argument is equivalent to `task_pt_regs(task)` for x86. Macros doesn't
       // work properly on bcc, so we need to re-implement.
       bpf_probe_read_kernel(
           &user_regs, sizeof(user_regs),
+          // Note - BCC emits an implicit bpf_probe_read_kernel() here (for the deref of 'task').
+          // I don't like the implicitness (and it will be something we'll need to fix if we're ever
+          // to move from BCC). But meanwhile, I tried to change it to explicit and the BPF assembly
+          // varies to much as I prefer to avoid this change now ;(
           (struct pt_regs *)(*(unsigned long*)((unsigned long)task + STACK_OFS) + THREAD_SIZE -
                             TOP_OF_KERNEL_STACK_PADDING) - 1);
     }

--- a/src/cc/compat/linux/types.h
+++ b/src/cc/compat/linux/types.h
@@ -53,7 +53,7 @@ typedef int bool;
 #define ENOSPC 28
 #define PAGE_SIZE 4096
 #define PAGE_MASK (~(PAGE_SIZE-1))
-#define THREAD_SIZE 8192
+#define THREAD_SIZE 16384
 
 struct pt_regs {
 /*

--- a/src/cc/compat/linux/types.h
+++ b/src/cc/compat/linux/types.h
@@ -53,7 +53,7 @@ typedef int bool;
 #define ENOSPC 28
 #define PAGE_SIZE 4096
 #define PAGE_MASK (~(PAGE_SIZE-1))
-#define THREAD_SIZE 2
+#define THREAD_SIZE_ORDER 2
 #define THREAD_SIZE (PAGE_SIZE << THREAD_SIZE_ORDER)
 
 struct pt_regs {

--- a/src/cc/compat/linux/types.h
+++ b/src/cc/compat/linux/types.h
@@ -53,7 +53,8 @@ typedef int bool;
 #define ENOSPC 28
 #define PAGE_SIZE 4096
 #define PAGE_MASK (~(PAGE_SIZE-1))
-#define THREAD_SIZE 16384
+#define THREAD_SIZE 2
+#define THREAD_SIZE (PAGE_SIZE << THREAD_SIZE_ORDER)
 
 struct pt_regs {
 /*


### PR DESCRIPTION
Recently (basically, post https://github.com/Granulate/bcc/pull/28) we've seen many native stacks failures (not counted in the errors that PyPerf prints, but we just didn't see any native frame).

I have investigated the issue. Assuming that I somehow caused an unwanted change in the BPF assembly, I diffed the assembly (dumping with `bpftool prog dump xlated id ...`) of our 3 programs (`on_event`, `read_python_stack`, `get_thread_state`) between "master" and 1 commit before #28.

The only diff was in `on_event`:
```
124c124
<  126: (07) r3 += 16216
---
>  126: (07) r3 += 8024
```
(`8024` in the new, `16216` in the old).

disassembling it through (I was too lazy to enable debug in BCC and see the matching source line....), it boiled down to:
```
(struct pt_regs *)(*(unsigned long*)((unsigned long)task + STACK_OFS) + THREAD_SIZE -
                            TOP_OF_KERNEL_STACK_PADDING) - 1);
```

`8024` is `8192 - TOP_OF_KERNEL_STACK_PADDING (0) - sizeof(struct pt_regs)` (the last `-1`).
`16216`, is, well, the same but with `16384`.

So I checked my definition of `THREAD_SIZE`. At first I thought that maybe my testing kernel (`4.15.0-72-generic`) has KASAN on (which causes the stack to grow) but obv that was wrong (and I still highly doubt we'll ever see it in production, hence ignoring that possibility at all).
Then I saw that I've defined it as `8192` while it was always defined as `PAGE_SIZE << THREAD_SIZE_ORDER` (and the latter is historically `2`....). Not sure how I slipped it in.

So the 2nd commit here fixes that, and after this change, I again see native stacks on `4.15.0-72-generic`.

What bugs me here, is why this change made zero effect when I tested it on my host machine (`5.4.0-91-generic`). Native stacks worked before, and they work after.... ???

I ran PyPerf with this diff:
```
diff --git a/examples/cpp/pyperf/PyPerfBPFProgram.cc b/examples/cpp/pyperf/PyPerfBPFProgram.cc
index 4023f6e3..0147fc7f 100644
--- a/examples/cpp/pyperf/PyPerfBPFProgram.cc
+++ b/examples/cpp/pyperf/PyPerfBPFProgram.cc
@@ -315,10 +315,12 @@ on_event(struct pt_regs* ctx) {
 
     // Are we in user mode?
     if (cs & 3) {
+      goto bad;
       // Yes - use the registers context given to the BPF program
       user_regs = *ctx;
     }
     else {
+      // goto bad;
       // No - use the registers context of usermode, that is stored on the stack.
 
       // The third argument is equivalent to `task_pt_regs(task)` for x86. Macros doesn't
@@ -418,6 +420,10 @@ on_event(struct pt_regs* ctx) {
 submit:
   events.perf_submit(ctx, &state->event, sizeof(struct event));
   return 0;
+
+bad:
+  event->error_code = ERROR_EMPTY_STACK;
+  goto submit;
 }
 
 /**
```

Essentially saying: if we take the `cs & 3 != 0` path, drop the stack. This resulted in all-dropped stacks!

If I swap between the `if`s (i.e move the `goto bad` to the other clause) - then I get no failures at all.

And if the Python program runs fully usermode (`while 1: pass`) or mostly kernel (`while 1: x = os.listdir("/")`), I still get the same behavior. Which bugs me because to my understanding, the `cs & 3` check tells us whether the perf interrupt was triggered while we were in usermode, or not. But on my kernel it seems that it *always* triggers in "usermode" (although I do see kernel stacks in the `os.listdir` case??) and on the `4.15` kernel - just the opposite.

* ~~It's as if the `bpf_probe_read_kernel(&cs, sizeof(cs), &(ctx->cs));` call always fails here and always succeeds there? IDK. Will check.~~ - checked on my box, it always passes.
* Or maybe the `cs` offset in `pt_regs` is messed up? - actually, that can't be because I saw no diff in the BPF assembly in that area.
  * I checked on my host - it reads 191 consistently.... Hmm. I'm not sure if it's a legit value for CS, so maybe the offset is indeed wrong. It reads 191 even when we're in kernel mode. (and `191 & 3 == 3` so we should be in UM??)
  * But how can the offset be incorrect if the BPF asm matches. Sigh
* ~~Or maybe this `cs` check was just broken to begin with?~~ - no, that's exactly the check `user_mode(struct pt_regs *regs)` does.

@YishaiZinkin , @d3dave  am I missing something clear here, or do we need to investigate it further (because, although it works fine now, I don't like the nonsense here)?