### PR TITLE
Use "Truncated Python Stack" instead of "Truncated"

### DIFF
--- a/examples/cpp/pyperf/PyPerfCollapsedPrinter.cc
+++ b/examples/cpp/pyperf/PyPerfCollapsedPrinter.cc
@@ -19,7 +19,7 @@ namespace ebpf {
 namespace pyperf {
 
 const static std::string kLostSymbol = "[Lost Symbol]";
-const static std::string kTruncatedStack = "[Truncated]";
+const static std::string kTruncatedStack = "[Truncated Python Stack]";
 
 PyPerfCollapsedPrinter::PyPerfCollapsedPrinter(std::string& output) {
   output_ = output;


### PR DESCRIPTION
"Truncated" is used by the gProfiler web UI, so it's confusing.