### PR TITLE
Implement reporting DSO names from PyPerf

### DIFF
--- a/examples/cpp/pyperf/PyPerf.cc
+++ b/examples/cpp/pyperf/PyPerf.cc
@@ -138,7 +138,7 @@ int main(int argc, char** argv) {
     found = found || parseStrArg({"-o", "--output"}, output);
     found = found || parseIntArg({"--fs-offset"}, fsOffset);
     found = found || parseIntArg({"--stack-offset"}, stackOffset);
-    found = found || parseFlag({"--do-insert-dso-name"}, insertDsoName);
+    found = found || parseFlag({"--insert-dso-name"}, insertDsoName);
     if (!found) {
       std::fprintf(stderr, "Unexpected argument: %s\n", argv[pos]);
       std::exit(1);

--- a/examples/cpp/pyperf/PyPerf.cc
+++ b/examples/cpp/pyperf/PyPerf.cc
@@ -84,6 +84,17 @@ int main(int argc, char** argv) {
     return false;
   };
 
+  auto parseFlag = [&](std::vector<std::string> argNames, bool& target, bool value=true) {
+    std::string arg(argv[pos]);
+    for (const auto& name : argNames) {
+      if (arg == name) {
+        target = value;
+        return true;
+      }
+    }
+    return false;
+  };
+
   auto parseIntListArg = [&](std::vector<std::string> argNames, std::vector<uint64_t>& target) {
     uint64_t value;
     if (parseIntArg(argNames, value)) {
@@ -107,6 +118,7 @@ int main(int argc, char** argv) {
   std::string output = "";
   uint64_t fsOffset = 0;
   uint64_t stackOffset = 0;
+  bool insertDsoName = false;
 
   while (true) {
     if (pos >= argc) {
@@ -126,6 +138,7 @@ int main(int argc, char** argv) {
     found = found || parseStrArg({"-o", "--output"}, output);
     found = found || parseIntArg({"--fs-offset"}, fsOffset);
     found = found || parseIntArg({"--stack-offset"}, stackOffset);
+    found = found || parseFlag({"--do-insert-dso-name"}, insertDsoName);
     if (!found) {
       std::fprintf(stderr, "Unexpected argument: %s\n", argv[pos]);
       std::exit(1);
@@ -169,7 +182,7 @@ int main(int argc, char** argv) {
     ebpf::pyperf::PyPerfProfiler profiler;
     profiler.update_interval = std::chrono::seconds{updateIntervalSecs};
 
-    auto res = profiler.init(symbolsMapSize, eventsBufferPages, kernelStacksMapSize, userStacksPages, fsOffset, stackOffset);
+    auto res = profiler.init(symbolsMapSize, eventsBufferPages, kernelStacksMapSize, userStacksPages, fsOffset, stackOffset, insertDsoName);
     if (res != ebpf::pyperf::PyPerfProfiler::PyPerfResult::SUCCESS) {
       std::exit((int)res);
     }

--- a/examples/cpp/pyperf/PyPerfNativeStackTrace.cc
+++ b/examples/cpp/pyperf/PyPerfNativeStackTrace.cc
@@ -56,8 +56,8 @@ NativeStackTrace::NativeStackTrace(uint32_t pid, const unsigned char *raw_stack,
   char sym[256];
   ProcSyms* procSymbols = nullptr;
   // reserve memory for platform-defined path limit AND the symbol
-  size_t buf_size = sizeof(sym) + PATH_MAX + 4;
-  unique_ptr<char[]> buf(new char[buf_size]);
+  size_t buf_size = sizeof(sym) + PATH_MAX + sizeof("() ");
+  char buf[buf_size];
 
   // The UPT implementation of these functions uses ptrace. We want to make sure they aren't getting called
   my_accessors.access_fpreg = NULL;
@@ -94,8 +94,8 @@ NativeStackTrace::NativeStackTrace(uint32_t pid, const unsigned char *raw_stack,
     unw_word_t ip;
     unw_get_reg(&cursor, UNW_REG_IP, &ip);
     if (procSymbols && procSymbols->resolve_addr(ip, &resolved_symbol, true)) {
-        snprintf(buf.get(), buf_size, "%s (%s)", resolved_symbol.demangle_name, resolved_symbol.module);
-        this->symbols.push_back(std::string(buf.get()));
+        snprintf(buf, buf_size, "%s (%s)", resolved_symbol.demangle_name, resolved_symbol.module);
+        this->symbols.push_back(std::string(buf));
     } else if (!unw_get_proc_name(&cursor, sym, sizeof(sym), &offset)) {
         int status = 0;
         char* demangled = nullptr;

--- a/examples/cpp/pyperf/PyPerfNativeStackTrace.cc
+++ b/examples/cpp/pyperf/PyPerfNativeStackTrace.cc
@@ -35,6 +35,9 @@ ProcSymbolsCache NativeStackTrace::procSymbolsCache;
 bool NativeStackTrace::insert_dso_name = false;
 const static double ProcSymbolsCacheTTL_S = 60;
 
+// external public symbol max size according to recommendation in c++ standard annex B
+const static int SymbolMaxSize = 1024;
+
 static double steady_time_since_epoch() {
   return std::chrono::duration_cast<std::chrono::duration<double>>(std::chrono::steady_clock::now().time_since_epoch()).count();
 }
@@ -53,10 +56,9 @@ NativeStackTrace::NativeStackTrace(uint32_t pid, const unsigned char *raw_stack,
   unw_accessors_t my_accessors = _UPT_accessors;
   my_accessors.access_mem = NativeStackTrace::access_mem;
   my_accessors.access_reg = NativeStackTrace::access_reg;
-  char sym[256];
   ProcSyms* procSymbols = nullptr;
   // reserve memory for platform-defined path limit AND the symbol
-  size_t buf_size = sizeof(sym) + PATH_MAX + sizeof("() ");
+  const size_t buf_size = SymbolMaxSize + PATH_MAX + sizeof("() ");
   char buf[buf_size];
 
   // The UPT implementation of these functions uses ptrace. We want to make sure they aren't getting called
@@ -84,7 +86,6 @@ NativeStackTrace::NativeStackTrace(uint32_t pid, const unsigned char *raw_stack,
     goto out;
   }
 
-  struct bcc_symbol resolved_symbol;
   if (NativeStackTrace::insert_dso_name) {
     procSymbols = get_proc_symbols(pid);
   }
@@ -92,18 +93,21 @@ NativeStackTrace::NativeStackTrace(uint32_t pid, const unsigned char *raw_stack,
   do {
     unw_word_t offset;
     unw_word_t ip;
+    struct bcc_symbol resolved_symbol;
     unw_get_reg(&cursor, UNW_REG_IP, &ip);
     if (procSymbols && procSymbols->resolve_addr(ip, &resolved_symbol, true)) {
         snprintf(buf, buf_size, "%s (%s)", resolved_symbol.demangle_name, resolved_symbol.module);
         this->symbols.push_back(std::string(buf));
-    } else if (!unw_get_proc_name(&cursor, sym, sizeof(sym), &offset)) {
+    // TODO: This function is very heavy. We should try to do some caching here, maybe in the
+    //       underlying UPT function.
+    } else if (!(res = unw_get_proc_name(&cursor, buf, sizeof(buf), &offset))) {
         int status = 0;
         char* demangled = nullptr;
-        demangled = abi::__cxa_demangle(sym, nullptr, nullptr, &status);
+        demangled = abi::__cxa_demangle(buf, nullptr, nullptr, &status);
         if (!status) {
           this->symbols.push_back(std::string(demangled));
         } else {
-          this->symbols.push_back(std::string(sym));
+          this->symbols.push_back(std::string(buf));
         }
         free(demangled);
     } else {
@@ -121,9 +125,9 @@ NativeStackTrace::NativeStackTrace(uint32_t pid, const unsigned char *raw_stack,
     // Unwind only until we get to the function from which the current Python function is executed.
     // On Python3 the main loop function is called "_PyEval_EvalFrameDefault", and on Python2 it's
     // "PyEval_EvalFrameEx".
-    if (memcmp(sym, "_PyEval_EvalFrameDefault",
+    if (memcmp(buf, "_PyEval_EvalFrameDefault",
                 sizeof("_PyEval_EvalFrameDefault")) == 0 ||
-        memcmp(sym, "PyEval_EvalFrameEx", sizeof("PyEval_EvalFrameEx")) == 0)
+        memcmp(buf, "PyEval_EvalFrameEx", sizeof("PyEval_EvalFrameEx")) == 0)
         {
       break;
     }
@@ -234,7 +238,7 @@ void NativeStackTrace::enable_dso_reporting() {
 }
 
 ProcSyms* NativeStackTrace::get_proc_symbols(uint32_t pid) {
-  static struct bcc_symbol_option symbol_options = {
+  struct bcc_symbol_option symbol_options = {
     .use_debug_file = 1,
     .check_debug_file_crc = 1,
     .lazy_symbolize = 1,

--- a/examples/cpp/pyperf/PyPerfNativeStackTrace.h
+++ b/examples/cpp/pyperf/PyPerfNativeStackTrace.h
@@ -6,11 +6,16 @@
 
 #include <libunwind-ptrace.h>
 
+#include <map>
+#include <memory>
 #include <string>
 #include <vector>
+#include "syms.h"
 
 namespace ebpf {
 namespace pyperf {
+
+typedef std::map<uint32_t, std::unique_ptr<ProcSyms>> ProcSymbolsCache;
 
 class NativeStackTrace {
  public:
@@ -19,6 +24,9 @@ class NativeStackTrace {
 
   std::vector<std::string> get_stack_symbol() const;
   bool error_occured() const;
+  static void prune_dead_pid(uint32_t dead_pid);
+  static void enable_dso_reporting();
+  static bool insert_dso_name;
 
  private:
   std::vector<std::string> symbols;
@@ -28,6 +36,7 @@ class NativeStackTrace {
   static size_t stack_len;
   static uintptr_t ip;
   static uintptr_t sp;
+  static ProcSymbolsCache procSymbolsCache;
 
   static int access_reg(unw_addr_space_t as, unw_regnum_t regnum,
                         unw_word_t *valp, int write, void *arg);

--- a/examples/cpp/pyperf/PyPerfNativeStackTrace.h
+++ b/examples/cpp/pyperf/PyPerfNativeStackTrace.h
@@ -15,7 +15,12 @@
 namespace ebpf {
 namespace pyperf {
 
-typedef std::map<uint32_t, std::unique_ptr<ProcSyms>> ProcSymbolsCache;
+typedef struct {
+    double timestamp_s;
+    std::unique_ptr<ProcSyms> proc_syms;
+} ProcSymbolsCacheEntry;
+
+typedef std::map<uint32_t, ProcSymbolsCacheEntry> ProcSymbolsCache;
 
 class NativeStackTrace {
  public:
@@ -43,6 +48,7 @@ class NativeStackTrace {
 
   static int access_mem(unw_addr_space_t as, unw_word_t addr, unw_word_t *valp,
                         int write, void *arg);
+  static ProcSyms* get_proc_symbols(uint32_t pid);
 };
 
 }  // namespace pyperf

--- a/examples/cpp/pyperf/PyPerfProfiler.cc
+++ b/examples/cpp/pyperf/PyPerfProfiler.cc
@@ -178,6 +178,9 @@ PyPerfProfiler::PyPerfResult PyPerfProfiler::init(unsigned int symbolsMapSize, u
   cflags.emplace_back(kFsOffsetFlag + std::to_string(fsOffset));
   cflags.emplace_back(kStackOffsetFlag + std::to_string(stackOffset));
 
+  if (insertDsoName) {
+    NativeStackTrace::enable_dso_reporting();
+  }
   auto initRes = bpf_.init(PYPERF_BPF_PROGRAM, cflags);
   if (initRes.code() != 0) {
     std::fprintf(stderr, "Failed to compile PyPerf BPF programs: %s\n",
@@ -222,9 +225,6 @@ PyPerfProfiler::PyPerfResult PyPerfProfiler::init(unsigned int symbolsMapSize, u
   }
 
   eventsBufferPages_ = eventsBufferPages;
-  if (insertDsoName) {
-    NativeStackTrace::enable_dso_reporting();
-  }
   initCompleted_ = true;
   return PyPerfResult::SUCCESS;
 }

--- a/examples/cpp/pyperf/PyPerfProfiler.cc
+++ b/examples/cpp/pyperf/PyPerfProfiler.cc
@@ -234,8 +234,10 @@ Populate the PidData BPF map.
 */
 bool PyPerfProfiler::populatePidTable() {
   bool result = false;
+
   // Populate config for each Python Process
   auto pid_config_map = bpf_.get_hash_table<int, PidData>(kPidCfgTableName);
+
   logInfo(3, "Pruning dead pids\n");
   auto pid_config_keys = pid_config_map.get_keys_offline();
   for (const auto pid : pid_config_keys) {
@@ -256,13 +258,16 @@ bool PyPerfProfiler::populatePidTable() {
   // Populate only those pids not seen before
   for (const auto pid : pids) {
     PidData pidData;
+
     if (!tryTargetPid(pid, pidData)) {
       // Not a Python Process
       continue;
     }
     pid_config_map.update_value(pid, pidData);
+
     result = true;
   }
+
   return result;
 }
 

--- a/examples/cpp/pyperf/PyPerfProfiler.cc
+++ b/examples/cpp/pyperf/PyPerfProfiler.cc
@@ -256,7 +256,6 @@ bool PyPerfProfiler::populatePidTable() {
   // Populate only those pids not seen before
   for (const auto pid : pids) {
     PidData pidData;
-
     if (!tryTargetPid(pid, pidData)) {
       // Not a Python Process
       continue;

--- a/examples/cpp/pyperf/PyPerfProfiler.h
+++ b/examples/cpp/pyperf/PyPerfProfiler.h
@@ -67,7 +67,8 @@ class PyPerfProfiler {
   // init must be invoked exactly once before invoking profile
   PyPerfResult init(unsigned int symbolsMapSize, unsigned int eventsBufferPages,
                     unsigned int kernelStacksMapSize, unsigned int userStacksPages,
-                    unsigned int fsOffset, unsigned int stackOffset);
+                    unsigned int fsOffset, unsigned int stackOffset,
+                    bool insertDsoName=true);
 
   PyPerfResult profile(int64_t sampleRate, int64_t sampleFreq, int64_t duration,
                        PyPerfSampleProcessor* processor);

--- a/examples/cpp/pyperf/PyPerfProfiler.h
+++ b/examples/cpp/pyperf/PyPerfProfiler.h
@@ -68,7 +68,7 @@ class PyPerfProfiler {
   PyPerfResult init(unsigned int symbolsMapSize, unsigned int eventsBufferPages,
                     unsigned int kernelStacksMapSize, unsigned int userStacksPages,
                     unsigned int fsOffset, unsigned int stackOffset,
-                    bool insertDsoName=true);
+                    bool insertDsoName);
 
   PyPerfResult profile(int64_t sampleRate, int64_t sampleFreq, int64_t duration,
                        PyPerfSampleProcessor* processor);


### PR DESCRIPTION
Support reporting DSO name for native frames.
Can be triggered with flag `--do-insert-dso-name`.